### PR TITLE
Pacific Atlantic Water Flow

### DIFF
--- a/solutions/day05/day_05.rs
+++ b/solutions/day05/day_05.rs
@@ -1,0 +1,79 @@
+impl Solution {
+    pub fn pacific_atlantic(heights: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
+        // Handle the edge case of an empty grid.
+        if heights.is_empty() || heights[0].is_empty() {
+            return vec![];
+        }
+
+        let m = heights.len();
+        let n = heights[0].len();
+
+        // `pacific_reachable` will store cells from which water can flow to the Pacific.
+        let mut pacific_reachable = vec![vec![false; n]; m];
+        // `atlantic_reachable` will store cells from which water can flow to the Atlantic.
+        let mut atlantic_reachable = vec![vec![false; n]; m];
+
+        // Start DFS from all border cells for both oceans.
+        for r in 0..m {
+            // Left border (Pacific)
+            Self::dfs(r, 0, &heights, &mut pacific_reachable);
+            // Right border (Atlantic)
+            Self::dfs(r, n - 1, &heights, &mut atlantic_reachable);
+        }
+
+        for c in 0..n {
+            // Top border (Pacific)
+            Self::dfs(0, c, &heights, &mut pacific_reachable);
+            // Bottom border (Atlantic)
+            Self::dfs(m - 1, c, &heights, &mut atlantic_reachable);
+        }
+
+        // Find the intersection of cells reachable from both oceans.
+        let mut result = Vec::new();
+        for r in 0..m {
+            for c in 0..n {
+                if pacific_reachable[r][c] && atlantic_reachable[r][c] {
+                    result.push(vec![r as i32, c as i32]);
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Helper DFS function to find all reachable cells from a starting point.
+    /// Traverses "uphill" from the ocean borders inland.
+    fn dfs(r: usize, c: usize, heights: &Vec<Vec<i32>>, visited: &mut Vec<Vec<bool>>) {
+        // If we've already visited this cell, we don't need to explore it again.
+        if visited[r][c] {
+            return;
+        }
+        
+        // Mark the current cell as reachable.
+        visited[r][c] = true;
+        
+        let m = heights.len();
+        let n = heights[0].len();
+        let current_height = heights[r][c];
+
+        // Define the four cardinal directions (North, South, East, West).
+        let directions: [(i32, i32); 4] = [(0, 1), (0, -1), (1, 0), (-1, 0)];
+        
+        for (dr, dc) in directions {
+            let new_r = r as i32 + dr;
+            let new_c = c as i32 + dc;
+
+            // Check if the neighbor is within the grid bounds.
+            if new_r >= 0 && new_r < m as i32 && new_c >= 0 && new_c < n as i32 {
+                let nr = new_r as usize;
+                let nc = new_c as usize;
+                
+                // If the neighbor hasn't been visited and its height allows "uphill" flow,
+                // continue the DFS from there.
+                if !visited[nr][nc] && heights[nr][nc] >= current_height {
+                    Self::dfs(nr, nc, heights, visited);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

### 🚀 What does this PR do?
<!-- Describe your changes in detail -->
Adds the solution for the LeetCode Daily Challenge on Sunday, October 5, 2025 (417. Pacific Atlantic Water Flow) in Rust.

The approach involves a two-pass Depth-First Search (DFS). Instead of checking paths from every cell to the oceans, we start from the ocean borders and traverse inland to find all cells that can flow down to each ocean. We run one pass for the Pacific Ocean (top and left borders) and another for the Atlantic Ocean (bottom and right borders). The final result is the set of cells that are found to be reachable in both passes.



### 📝 Issue Reference:
<!-- Link to the issue that your PR addresses -->
Fixes issue: # (Mention the issue number this PR solves)

### 🔍 Checklist:
Please ensure the following before submitting your PR:
- [x] I have placed my solution in the correct folder (`solutions/dayXX/`).
- [x] My code follows clean coding practices and is efficient.
- [x] I have added comments in my code to explain the approach.
- [ ] I have updated the `README.md` for the specific day with a brief explanation of my solution.
- [x] I have tested the solution on LeetCode and it works correctly.

🔧 Solution Details:
Language Used: Rust

Time Complexity: O(m×n), where m is the number of rows and n is the number of columns. Each cell is visited at most twice (once for the Pacific DFS and once for the Atlantic DFS).

Space Complexity: O(m×n) for the two boolean matrices used to track reachability and for the recursion stack in the worst-case scenario.

### 🌟 Additional Notes (if any):
<!-- Add any additional info you want reviewers to know (e.g., edge cases handled, alternative approaches considered, etc.) -->
The key to this solution is reversing the problem. Instead of a multi-source pathfinding problem from every cell, it becomes two simpler single-source pathfinding problems starting from all border cells of each ocean. This is significantly more efficient.
